### PR TITLE
Add support for custom callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ When you click on the notification, it will open the url in your web browser.
 The configuration has the following format :
 
       [
-         { url : '', selector: '', frequence: 0 },
+         { url : '', selector: '', frequence: 0, callback: function(innerText, innerHTML) {} },
          ...
       ]
 
 The frequence is optional (default: 1 minute).
+The callback is optional. By default the notification pops up and nothing else happens. If you do specify one, you can then `return false` to prevent the notification.
 
 ## How does it work ?
 

--- a/test.js
+++ b/test.js
@@ -10,5 +10,15 @@ fomo([
       url: 'http://stackoverflow.com/',
       selector: '.question-summary > div.summary > h3 > a',
     },
+    {
+    	url: 'https://www.reddit.com/new/',
+      	selector: '.thing > div.entry.unvoted > p.title',
+      	frequence: 10e3, // once every second
+      	callback: function(text, html) {
+      		console.log("Callbacks work.");
+      		console.log("Text is " + text);
+      		console.log("Html is " + html);
+      	}
+    },
 ]);
 


### PR DESCRIPTION
This adds support for custom callbacks, allowing a slightly more general use of this module within external node code. A simple test case is included.

This covers the use case "wait until text changes to call this function". For completeness, the called function can then decide to prevent a notification (this allows someone to "filter" notification worth sending, for instance).

The defaults remain the same if no callback is specified, though.
